### PR TITLE
Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: node_js
+node_js:
+  - "lts/*"
+cache:
+  directories:
+    - "$HOME/.npm"
+jobs:
+  fast_finish: true
+  include:
+    - stage: backend
+        install:
+          - cd ./backend
+          - npm ci
+    - stage: frontend
+        install:
+          - cd ./frontend
+          - npm ci
+    - stage: Lint backend
+        install:
+          - cd ./backend
+          - npm ci
+        script:
+          - npm run lint

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "description": "A web application for finding on-going, or soon-to-start group activities in your local area",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds basic Travis-CI integration by linting the backend directory.
Closes #8 

> Note: Linting will fail on this PR as some of the files in the repo haven't had linting rules applied to them yet. Those linting problems are addressed in #65.